### PR TITLE
Add catalog of thingiverse filter adapters

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,0 +1,36 @@
+# Adapters
+
+The masks in this repository are based on the NATO 40mm respirator thread standard. In order to allow these designs to interoperate with a wider variety of off-the-shelf components, this folder contains additional adapters which will convert the NATO threading to alternate standards. This is useful for anyone who would like to use off the shelf filters that are not NATO threaded.
+
+## External Adapters
+
+| Filter Connector | Name / Link | Creator | Connectors Tested |
+| - | - | - | - |
+| 3M Bayonet | [40MM NATO (RD40x1/7) to 3M™ Filter Adapter](https://www.thingiverse.com/thing:4245358) | AgapeIngenium | &#10007; |
+| AOSafety R5700 8051 Bayonet | [40MM NATO (RD40X1/7) to AOSafety® R5700 8051 Bayonet Filter Adapter](https://www.thingiverse.com/thing:4265538) | AgapeIngenium | &#10007; |
+| AOSafety Threaded | [40MM NATO (RD40X1/7) to AOSafety® Threaded Filter Adapter](https://www.thingiverse.com/thing:4273365) | AgapeIngenium | &#10007; |
+| Delta Plus M3000 Mars Series | [40MM NATO (RD40X1/7) to Delta Plus M3000 Mars Series Filter Adapter](https://www.thingiverse.com/thing:4311197) | AgapeIngenium | &#10007; |
+| Delta Plus M6000 Jupiter Series | [40MM NATO (RD40X1/7) to Delta Plus M6000 Jupiter Series Filter Adapter](https://www.thingiverse.com/thing:4311200) | AgapeIngenium | &#10007; |
+| Draeger X-plore (3000/5000 Series) | [40MM NATO (RD40x1/7) to Draeger X-plore® Filter (3000/5000 Series) Adapter](https://www.thingiverse.com/thing:4329276) | AgapeIngenium | &#10007; |
+| ENHA Rockman 7300 Series | [40MM NATO (RD40x1/7) to ENHA Rockman 7300 Series Filter Adapter](https://www.thingiverse.com/thing:4329610) | AgapeIngenium | &#10007; |
+| GOST | [NATO to GOST & GOST to NATO (RD40x1/7-KR40H4) Adapter Set](https://www.thingiverse.com/thing:4321450) | AgapeIngenium | &#10007; |
+| Honeywell/Honeywell North | [40MM NATO (RD40X1/7) to Honeywell/Honeywell North® Filter Adapter](https://www.thingiverse.com/thing:4268775) | AgapeIngenium | &#10007; |
+| Honeywell Safety Sperian / Survivair ValuAir Respirator (Bayonet) | [40MM NATO (RD40x1/7) to Honeywell Safety Sperian® /Survivair™ ValuAir® Respirator (Bayonet) Filter Adapter](https://www.thingiverse.com/thing:4345345) | AgapeIngenium | &#10007; |
+| Honeywell Sperian | [40MM NATO (RD40X1/7) to Honeywell Sperian® Filter Adapter](https://www.thingiverse.com/thing:4297348) | AgapeIngenium | &#10007; |
+| JSP Force8 | [40MM NATO (RD40X1/7) to JSP® Force™8 Filter Adapter](https://www.thingiverse.com/thing:4294203) | AgapeIngenium | &#10007; |
+| MEDOP EUROPA Comfort Series | [40MM NATO (RD40x1/7) to MEDOP Threaded Filter (EUROPA Comfort Series) Adapter](https://www.thingiverse.com/thing:4380984) | AgapeIngenium | &#10007; |
+| Milla EURMASK ETNA (Bayonet) Series | [40MM NATO (RD40x1/7) to Milla EURMASK® ETNA (Bayonet) Series Filter Adapter](https://www.thingiverse.com/thing:4342320) | AgapeIngenium | &#10007; |
+| Milla EURMASK (Uno/New) Series Threaded | [40MM NATO (RD40x1/7) to Milla EURMASK® (Uno/New) Series Threaded Filter Adapter](https://www.thingiverse.com/thing:4342343) | AgapeIngenium | &#10007; |
+| Moldex 7000/9000 Series EasyLock Bayonet | [40MM NATO (RD40X1/7) to Moldex® 7000/9000 Series EasyLock® Bayonet Filter Adapter](https://www.thingiverse.com/thing:4275446) | AgapeIngenium | &#10007; |
+| Moldex 8000 | [40MM NATO (RD40x1/7) to Moldex® 8000 Series Filter Adapter](https://www.thingiverse.com/thing:4422042) | AgapeIngenium | &#10007; |
+| MSA Bayonet | [40MM NATO (RD40X1/7) to MSA® Bayonet Filter Adapter](https://www.thingiverse.com/thing:4265715) | AgapeIngenium | &#10007; |
+| MSA Comfo Classic Threaded | [40MM NATO (RD40X1/7) to MSA® Comfo Classic Threaded Filter Adapter](https://www.thingiverse.com/thing:4267676) | AgapeIngenium | &#10007; |
+| MSA Phalanx | [40MM NATO (RD40x1/7) to MSA® Phalanx Filter Adapter](https://www.thingiverse.com/thing:4399965) | AgapeIngenium | &#10007; |
+| Portwest Bayonet | [40MM NATO (RD40X1/7) to Portwest® Bayonet Filter Adapter](https://www.thingiverse.com/thing:4273464) | AgapeIngenium | &#10007; |
+| Scott 742 Series (Bayonet) | [40MM NATO (RD40x1/7) to Scott® 742 Series (Bayonet) Filter Adapter](https://www.thingiverse.com/thing:4347531) | AgapeIngenium | &#10007; |
+| Secura BC Bayonet | [40MM NATO (RD40X1/7) to Secura BC Bayonet Filter Adapter](https://www.thingiverse.com/thing:4294187) | AgapeIngenium | &#10007; |
+| Spasciani Bayonet (Duetta and Duo) 2000 Series | [40MM NATO (RD40x1/7) to Spasciani Bayonet (Duetta and Duo) 2000 Series Filter Adapter](https://www.thingiverse.com/thing:4378232) | AgapeIngenium | &#10007; |
+| Sundstrom SR Series (SR100/200/900) | [40MM NATO (RD40x1/7) to Sundstrom SR Series Filter (SR100/200/900) Adapter](https://www.thingiverse.com/thing:4338105) | AgapeIngenium | &#10007; |
+
+## Misc
+NATO 40mm female-female coupler: https://www.thingiverse.com/thing:4304055 by AgapeIngenium


### PR DESCRIPTION
This commit adds a table of filter connector adapters to the adapters readme. All of the adapters listed are nato to something else, and are applicable to any nato mask we make.